### PR TITLE
Windows support

### DIFF
--- a/about.nimble
+++ b/about.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Edgar Cabrera"
 description   = "Executable for finding information about programs in PATH"
 license       = "MIT"

--- a/src/about.nim
+++ b/src/about.nim
@@ -13,7 +13,7 @@ Options:
   --history     Search for matches in history
 """
 
-import docopt, sets, os, osproc, strutils
+import docopt, sets, os, osproc, strutils, sequtils
 import aboutpkg/fileutils
 
 let
@@ -25,8 +25,15 @@ proc isExecutable(path: string): bool =
   let permissions = getFilePermissions(path)
   fpUserExec in permissions
 
+proc hasValidExtension(path: string): bool =
+  result = true
+  if existsEnv("PATHEXT"):
+    let extensions = getEnv("PATHEXT").split({PathSep})
+    let (_, _, ext) = path.splitFile()
+    result = extensions.anyIt(ext.cmpIgnoreCase(it) == 0)
+
 proc isProgram(path: string): bool =
-  existsFile(path) and isExecutable(path)
+  existsFile(path) and isExecutable(path) and hasValidExtension(path)
 
 proc isMatch(path: string, pattern: string, nameOnly: bool): bool =
   let target = if nameOnly: baseName(path) else: path

--- a/src/about.nim
+++ b/src/about.nim
@@ -17,7 +17,7 @@ import docopt, sets, os, osproc, strutils
 import aboutpkg/fileutils
 
 let
-  args = docopt(doc, version = "about 0.1.0")
+  args = docopt(doc, version = "about 0.1.1")
   pattern = $args["<pattern>"]
   history = args["--history"]
 
@@ -33,7 +33,7 @@ proc isMatch(path: string, pattern: string, nameOnly: bool): bool =
   pattern in target
 
 iterator pathElements(): string =
-  for element in toSet(getEnv("PATH").split({':'})):
+  for element in toSet(getEnv("PATH").split({PathSep})):
     for _, path in walkDir(element):
       yield path
 


### PR DESCRIPTION
added use of the the generic `PathSep` value from `ospaths` to make it behave correctly on windows, also added an additional check of the `PATHEXT` env-var (it is used on windows to declare which file-exetensions are actually executables).

bumped the version number by 0.0.1

